### PR TITLE
xfail for attrs using string type references

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py35,py36,py37,mypy
 deps =
     pytest
     pytest-cov
+    attrs
 
 commands =
     py.test \


### PR DESCRIPTION
`get_type_hint` function fails on attrs classes that reference  a type using a string. The reason is that `__init__.__globals__` original content is lost by attrs. See https://github.com/python-attrs/attrs/issues/593

This PR adds a xfail test for such a case. 