### PR TITLE
declare Python 3.8 support, enable 3.8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: python
 
+branches:
+  only:
+    - master
+    - /^\d\.\d+$/
+    - /^\d\.\d+\.\d+(rc\d+|\.dev\d+)?$/
+
 matrix:
   include:
   - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
     env: TOXENV=py36
   - python: 3.7
     env: TOXENV=py37
+  - python: 3.8
+    env: TOXENV=py38
   - python: 3.6
     env: TOXENV=mypy
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     env: TOXENV=py37
   - python: 3.8
     env: TOXENV=py38
-  - python: 3.6
+  - python: 3.7
     env: TOXENV=mypy
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,6 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,mypy
+envlist = py35,py36,py37,py38,mypy
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,6 @@ commands =
 
 [testenv:mypy]
 deps =
-    mypy==0.720
+    mypy==0.761
 
 commands = mypy --ignore-missing-imports --no-warn-no-return andi tests


### PR DESCRIPTION
* Python 3.8 is enabled in tox and on Travis
* Python 3.8 support is declared in setup.py
* unrelated: CI is disabled for branches in this repository, to ensure tests for PRs like this are run once, not twice.
* unrelated: mypy is upgraded, just in case