### PR TITLE
plan and build methods for recursive dependency injection and object building

### DIFF
--- a/andi/__init__.py
+++ b/andi/__init__.py
@@ -1,2 +1,5 @@
 # -*- coding: utf-8 -*-
-from .andi import inspect, to_provide, plan, plan_str, build
+from .andi import (
+    inspect, to_provide, plan, plan_str, build, CyclicDependencyError,
+    NonProvidableError
+)

--- a/andi/__init__.py
+++ b/andi/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 from .andi import (
     inspect, to_provide, plan, plan_str, build, CyclicDependencyError,
-    NonProvidableError
+    NonProvidableError, FunctionArguments
 )

--- a/andi/__init__.py
+++ b/andi/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-from .andi import inspect, to_provide
+from .andi import inspect, to_provide, plan, plan_str, build

--- a/andi/andi.py
+++ b/andi/andi.py
@@ -132,15 +132,14 @@ def _plan(arguments_or_class: Union[
             if sel_cls not in tasks:
                 tasks.update((_plan(sel_cls, can_provide, externally_provided,
                                     dependency_stack)))
+            type_for_arg[argname] = sel_cls
         else:
-            msg = "Any of {} types are required ".format(as_class_names(types))
+            # Non fulfilling all deps is allowed for non type inputs.
             if input_is_type:
-                msg += "in {} __init__ but none can be provided".format(
-                    as_class_names(arguments_or_class))
-            else:
-                msg += "for the argument {} but none can be provided".format(argname)
-            raise NonProvidableError(msg)
-        type_for_arg[argname] = sel_cls
+                msg = "Any of {} types are required ".format(as_class_names(types))
+                msg += " in {} __init__ but none can be provided".format(
+                        as_class_names(arguments_or_class))
+                raise NonProvidableError(msg)
 
     if input_is_type:
         tasks[cls] = type_for_arg

--- a/andi/andi.py
+++ b/andi/andi.py
@@ -110,7 +110,7 @@ def _plan(arguments_or_class: Union[
             raise TypeError("Cyclic dependency found. Dependency graph: {}".format(
                 " -> ".join(as_class_names(dependency_stack + [cls]))))
         dependency_stack = dependency_stack + [cls]
-        params_list = inspect(cls)
+        params_list = inspect(cls.__init__)
     else:
         params_list = typing.cast(Dict[str, List[Optional[Type]]], arguments_or_class)
 

--- a/andi/andi.py
+++ b/andi/andi.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
+import typing
+from collections import OrderedDict
 from typing import (
-    Dict, List, Optional, Type, Callable, Union, Container,
+    Any, Dict, List, Optional, Type, Callable, Union, Container,
     get_type_hints,
-)
+    Tuple)
 
 from andi.typeutils import get_union_args, is_union, get_globalns
+from utils import as_class_names
 
 
 def inspect(func: Callable) -> Dict[str, List[Optional[Type]]]:
@@ -24,15 +27,18 @@ def inspect(func: Callable) -> Dict[str, List[Optional[Type]]]:
     return res
 
 
+TypeContainerOrCallable = Union[
+    Container[Type],
+    Callable[[Optional[Type]], bool]
+]
+
+
 def to_provide(
         arguments_or_func: Union[
             Callable,
             Dict[str, List[Optional[Type]]]
         ],
-        can_provide: Union[
-            Container[Type],
-            Callable[[Optional[Type]], bool]
-        ]
+        can_provide: TypeContainerOrCallable
         ) -> Dict[str, Optional[Type]]:
     """
     Return a dictionary ``{argument_name: type}`` with types which should
@@ -60,3 +66,75 @@ def to_provide(
                 result[argname] = cls
                 break
     return result
+
+
+Plan = typing.OrderedDict[Type, Dict[str, Type]]
+
+
+def plan(cls: Type,
+         can_provide: TypeContainerOrCallable,
+         externally_provided: TypeContainerOrCallable) -> Plan:
+    """ TODO: Here the docstring """
+    _plan(cls, can_provide, externally_provided, None)
+
+
+def _plan(cls: Type,
+         can_provide: TypeContainerOrCallable,
+         externally_provided: TypeContainerOrCallable,
+         _dependency_stack=None) -> Plan:
+    _dependency_stack = _dependency_stack or []
+    if isinstance(can_provide, Container):
+        can_provide = can_provide.__contains__
+    if isinstance(externally_provided, Container):
+        externally_provided = externally_provided.__contains__
+
+    tasks: Plan = OrderedDict()
+    type_for_arg: Dict[str, Type] = {}
+
+    if externally_provided(cls):
+        tasks[cls] = {}
+        return tasks
+
+    if cls in _dependency_stack:
+        raise TypeError("Cyclic dependency found. Dependency graph: {}".format(
+            " -> ".join(as_class_names(_dependency_stack + [cls]))))
+    _dependency_stack = _dependency_stack + [cls]
+
+    for argname, types in inspect(cls).items():
+        sel_cls = None
+        for candidate in types:
+            if can_provide(candidate):
+                sel_cls = candidate
+                break
+
+        if sel_cls:
+            if sel_cls not in tasks:
+                tasks.update((_plan(sel_cls, can_provide, externally_provided,
+                                   _dependency_stack)))
+        else:
+            raise TypeError(f"Any of {as_class_names(types)} types are required "
+                            f"for {as_class_names(cls)} but none can be provided")
+        type_for_arg[argname] = sel_cls
+
+    tasks[cls] = type_for_arg
+    return tasks
+
+
+def build(plan: Plan, stock: Optional[Dict[Type, Any]] = None):
+    stock = stock or {}
+    instances = {}
+    for cls, params in plan.items():
+        if cls in stock:
+            instances[cls] = stock[cls]
+        else:
+            kwargs = {param: instances[pcls]
+                      for param, pcls in params.items()}
+            instances[cls] = cls(**kwargs)
+    return instances
+
+
+def plan_str(plan: Plan):
+    str_dict = {}
+    for cls, params in plan.items():
+        str_dict[cls.__name__] = {p: c.__name__ for p, c in params.items()}
+    return "\n".join(map(str, str_dict.items()))

--- a/andi/andi.py
+++ b/andi/andi.py
@@ -20,7 +20,7 @@ def inspect(func: Callable) -> Dict[str, List[Optional[Type]]]:
     res = {}
     for key, tp in annotations.items():
         if is_union(tp):
-            res[key] = get_union_args(tp)
+            res[key] = list(tp.__args__)
         else:
             res[key] = [tp]
     return res
@@ -159,7 +159,7 @@ def _plan(class_or_func: Union[Type, Callable],
 
     for argname, types in arguments.items():
         sel_cls = select_type(types, can_provide)
-        if sel_cls:
+        if sel_cls is not None:
             if sel_cls not in tasks:
                 tasks.update((_plan(sel_cls, can_provide, externally_provided,
                                     dependency_stack)))

--- a/andi/typeutils.py
+++ b/andi/typeutils.py
@@ -74,7 +74,7 @@ def _get_globalns_for_attrs(func: Callable) -> Dict:
     Also required to support attrs classes when
     ``from __future__ import annotations`` is used (default for python 4.0).
     See https://github.com/python-attrs/attrs/issues/593 """
-    if func.__module__ in sys.modules:
+    if getattr(func, '__module__', None) in sys.modules:
         return dict(sys.modules[func.__module__].__dict__)
     else:
         # Theoretically this can happen if someone writes

--- a/andi/typeutils.py
+++ b/andi/typeutils.py
@@ -19,14 +19,18 @@ def is_union(tp) -> bool:
 
 
 def get_union_args(tp) -> List:
-    """ Return a list of typing.Union args.
-    NoneType objects are converted to None for simplicity.
-    """
-    return _none_type_to_none(tp.__args__)
+    """ Return a list of typing.Union args. """
+    return list(tp.__args__)
 
 
-def _none_type_to_none(lst):
-    return [(el if el is not None.__class__ else None) for el in lst]
+def select_type(types, can_provide):
+    """ Choose the first type that can be provided. None otherwise. """
+    sel_cls = None
+    for candidate in types:
+        if can_provide(candidate):
+            sel_cls = candidate
+            break
+    return sel_cls
 
 
 def issubclass_safe(cls, bases) -> bool:

--- a/andi/typeutils.py
+++ b/andi/typeutils.py
@@ -23,10 +23,11 @@ def get_union_args(tp) -> List:
     return list(tp.__args__)
 
 
-def select_type(types, can_provide):
+def select_type(types, can_provide, bindings):
     """ Choose the first type that can be provided. None otherwise. """
     sel_cls = None
     for candidate in types:
+        candidate = bindings(candidate) or candidate
         if can_provide(candidate):
             sel_cls = candidate
             break

--- a/andi/utils.py
+++ b/andi/utils.py
@@ -1,0 +1,6 @@
+def as_class_names(cls_or_collection):
+    try:
+        return [cls.__name__ for cls in cls_or_collection]
+    except:
+        return cls_or_collection.__name__
+

--- a/tests/test_andi.py
+++ b/tests/test_andi.py
@@ -63,27 +63,27 @@ def test_optional():
     def func(x: Optional[Foo]):
         pass
 
-    assert andi.inspect(func) == {'x': [Foo, None]}
+    assert andi.inspect(func) == {'x': [Foo, type(None)]}
 
     assert andi.to_provide(func, {Foo, Bar}) == {'x': Foo}
-    assert andi.to_provide(func, {Foo, Bar, None}) == {'x': Foo}
+    assert andi.to_provide(func, {Foo, Bar, type(None)}) == {'x': Foo}
     assert andi.to_provide(func, {Bar}) == {}
-    assert andi.to_provide(func, {Bar, None}) == {'x': None}
+    assert andi.to_provide(func, {Bar, type(None)}) == {'x': type(None)}
 
 
 def test_optional_union():
     def func(x: Optional[Union[Foo, Baz]]):
         pass
 
-    assert andi.inspect(func) == {'x': [Foo, Baz, None]}
+    assert andi.inspect(func) == {'x': [Foo, Baz, type(None)]}
 
     assert andi.to_provide(func, {Foo, Bar}) == {'x': Foo}
-    assert andi.to_provide(func, {Baz, Foo, None}) == {'x': Foo}
+    assert andi.to_provide(func, {Baz, Foo, type(None)}) == {'x': Foo}
     assert andi.to_provide(func, {Baz}) == {'x': Baz}
     assert andi.to_provide(func, {Bar}) == {}
-    assert andi.to_provide(func, {Bar, None}) == {'x': None}
+    assert andi.to_provide(func, {Bar, type(None)}) == {'x': type(None)}
     assert andi.to_provide(func, {}) == {}
-    assert andi.to_provide(func, {None}) == {'x': None}
+    assert andi.to_provide(func, {type(None)}) == {'x': type(None)}
 
 
 def test_not_annotated():

--- a/tests/test_andi.py
+++ b/tests/test_andi.py
@@ -31,6 +31,7 @@ def test_andi():
     def func3(x: Bar, y: Foo):
         pass
 
+    assert andi.inspect(Foo.__init__) == {}
     assert andi.inspect(func1) == {'x': [Foo]}
     assert andi.inspect(func2) == {}
     assert andi.inspect(func3) == {'x': [Bar], 'y': [Foo]}

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Optional
 
 import pytest
 
@@ -117,3 +117,9 @@ def test_plan_for_func():
     fn(**kwargs)
 
 
+def test_plan_with_optionals():
+    def fn(a: Optional[str]):
+        pass
+
+    assert andi.plan(fn, [type(None), str], [str]) == {str: {}}
+    assert andi.plan(fn, [type(None)], []) == {type(None): {}}

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -68,6 +68,8 @@ def test_cannot_be_provided():
     assert plan == [(B, {}), (WithB, {"b": B})]
     with pytest.raises(andi.NonProvidableError):
         andi.plan(WithB, [WithB], [])
+    with pytest.raises(andi.NonProvidableError):
+        andi.plan(WithB, [], [])
 
     class WithOptionals:
         def __init__(self, a_or_b: Union[A, B]): pass

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -92,7 +92,11 @@ def test_externally_provided():
 
     plan = andi.plan(E, ALL, [A, B, D])
     seq = list(plan.keys())
-    assert set(seq[:2]) == {A, B}
-    assert seq[2:] == [C, D, E]
+    assert seq.index(A) < seq.index(C)
+    assert seq.index(B) < seq.index(C)
+    assert seq.index(D) < seq.index(E)
+    assert seq.index(C) < seq.index(E)
+    for cls in (A, B, D):
+        assert plan[cls] == {}
     assert plan[C] == {'a': A, 'b': B}
     assert plan[E] == {'b': B, 'c': C, 'd': D}

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -3,7 +3,7 @@ from typing import Union, Optional
 import pytest
 
 import andi
-from andi import plan_str
+from andi import plan_str, FunctionArguments
 
 
 class A:
@@ -112,6 +112,7 @@ def test_plan_for_func():
         assert type(c) == C
 
     plan = andi.plan(fn, ALL, [A])
+    assert list(plan.items())[-1] == (FunctionArguments, {'e': E, 'c': C})
     instances = andi.build(plan, {A: ""})
     kwargs = dict(other="yeah!", e=instances[E], c=instances[C])
     fn(**kwargs)
@@ -121,7 +122,8 @@ def test_plan_with_optionals():
     def fn(a: Optional[str]):
         pass
 
-    assert andi.plan(fn, [type(None), str], [str]) == {str: {}}
+    assert andi.plan(fn, [type(None), str], [str]) == \
+           {str: {}, FunctionArguments: {'a': str}}
     plan = andi.plan(fn, [type(None)], [])
-    assert plan == {type(None): {}}
+    assert plan == {type(None): {}, FunctionArguments: {'a': type(None)}}
     assert andi.build(plan)[type(None)] == None

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -109,7 +109,7 @@ def test_plan_for_func():
         assert type(e) == E
         assert type(c) == C
 
-    plan = andi.plan(andi.inspect(fn), ALL, [A])
+    plan = andi.plan(fn, ALL, [A])
     instances = andi.build(plan, {A: ""})
     kwargs = dict(other="yeah!", e=instances[E], c=instances[C])
     fn(**kwargs)

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+
+import pytest
+
+import andi
+
+
+@dataclass
+class A:
+    e: 'E'
+
+
+@dataclass
+class B: pass
+
+
+@dataclass
+class C:
+    a: A
+    b: B
+
+
+@dataclass
+class D:
+    a: A
+    c: C
+
+
+@dataclass
+class E:
+    b: B
+    c: C
+    d: D
+
+
+def test_plan_and_build():
+    plan = andi.plan(E, lambda x: True, [A])
+    print(andi.plan_str(plan))
+    instances = andi.build(plan, {A: ""})
+    assert type(instances[E]) == E
+
+
+def test_cyclic_dependency():
+    with pytest.raises(TypeError):
+        andi.plan(E, lambda x: True, [])

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -122,4 +122,6 @@ def test_plan_with_optionals():
         pass
 
     assert andi.plan(fn, [type(None), str], [str]) == {str: {}}
-    assert andi.plan(fn, [type(None)], []) == {type(None): {}}
+    plan = andi.plan(fn, [type(None)], [])
+    assert plan == {type(None): {}}
+    assert andi.build(plan)[type(None)] == None

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -3,6 +3,7 @@ from typing import Union
 import pytest
 
 import andi
+from andi import plan_str
 
 
 class A:
@@ -100,3 +101,17 @@ def test_externally_provided():
         assert plan[cls] == {}
     assert plan[C] == {'a': A, 'b': B}
     assert plan[E] == {'b': B, 'c': C, 'd': D}
+
+
+def test_plan_for_func():
+    def fn(other: str, e: E, c: C):
+        assert other == 'yeah!'
+        assert type(e) == E
+        assert type(c) == C
+
+    plan = andi.plan(andi.inspect(fn), ALL, [A])
+    instances = andi.build(plan, {A: ""})
+    kwargs = dict(other="yeah!", e=instances[E], c=instances[C])
+    fn(**kwargs)
+
+

--- a/tests/test_typeutils.py
+++ b/tests/test_typeutils.py
@@ -9,4 +9,4 @@ def test_get_union_args():
 
 
 def test_get_union_args_optional():
-    assert get_union_args(Optional[Union[str, int]]) == [str, int, None]
+    assert get_union_args(Optional[Union[str, int]]) == [str, int, None.__class__]


### PR DESCRIPTION
Two methods are introduced. 
`plan` recurses over the dependencies and produces a plan that can be used to build the required instances. Takes care of:
* recurses to find all dependencies
* detecting cyclic dependencies
* choosing prefered type in multiple cases
* detects if some dependencies cannot be fulfilled 
* returns a sequential plan that can be followed to build all the dependencies
* support for bindings as a mechanism to plug and play different types in the dependencies

`build` method build the actual instances from a given plan and a provided stock of already existing instances. 
 