### PR TITLE
[WIP] Recursive DI refactor

### DIFF
--- a/andi/andi.py
+++ b/andi/andi.py
@@ -149,18 +149,19 @@ def plan_for_func(func: Callable, *,
     ...     assert b.a is a
     ...     return 'Called with {}, {}, {}'.format(a.value, b.value, non_annotated)
     ...
+    >>> def _get_kwargs(instances, kwarg_types):
+    ...     return {name: instances[cls] for name, cls in kwarg_types.items()}
+    ...
     >>> def build(plan):  # Build all the instances from a plan
     ...     instances = {}
     ...     for cls, args in plan.items():
-    ...         kwargs = {arg: instances[arg_cls]
-    ...                   for arg, arg_cls in args.items()}
-    ...         instances[cls] = cls(**kwargs)
+    ...         instances[cls] = cls(**_get_kwargs(instances, args))
     ...     return instances
     ...
     >>> plan, fulfilled_args = plan_for_func(fn, is_injectable=[A, B])
     >>> instances = build(plan)
-    >>> kwargs = {arg: instances[arg_cls] for arg, arg_cls in fulfilled_args.items()}
-    >>> fn(non_annotated='non_annotated', **kwargs)
+    >>> fn(non_annotated='non_annotated',
+    ...    **_get_kwargs(instances, fulfilled_args))
     'Called with a, b, non_annotated'
 
 

--- a/andi/andi.py
+++ b/andi/andi.py
@@ -191,12 +191,12 @@ def plan_for_func(func: Callable, *,
     assert not isinstance(func, type)
     is_injectable, externally_provided = _ensure_input_type_checks_as_func(
         is_injectable, externally_provided)
-    fulfilled_arguments = plan.pop(FunctionArguments)
     plan = _plan(func,
                  is_injectable=is_injectable,
                  externally_provided=externally_provided,
                  strict=strict,
                  dependency_stack=None)
+    fulfilled_arguments = plan.pop(_FunctionArguments)
     return plan, fulfilled_arguments
 
 
@@ -311,7 +311,7 @@ def _plan(class_or_func: Union[Type, Callable], *,
                 raise NonProvidableError(msg)
 
 
-    plan_seq[cls if input_is_type else FunctionArguments] = type_for_arg
+    plan_seq[cls if input_is_type else _FunctionArguments] = type_for_arg
     return plan_seq
 
 
@@ -343,7 +343,7 @@ def _ensure_input_type_checks_as_func(can_provide, externally_provided
     return can_provide, externally_provided
 
 
-class FunctionArguments:
+class _FunctionArguments:
     """ Key marker to return the inspected function arguments into the
     ``Plan`` returned by the ``_plan`` function """
     pass

--- a/andi/andi.py
+++ b/andi/andi.py
@@ -314,12 +314,9 @@ def _plan(class_or_func: Union[Type, Callable], *,
 
 def _select_type(types, is_injectable, externally_provided):
     """ Choose the first type that can be provided. None otherwise. """
-    sel_cls = None
     for candidate in types:
         if is_injectable(candidate) or externally_provided(candidate):
-            sel_cls = candidate
-            break
-    return sel_cls
+            return candidate
 
 
 def _ensure_can_provide_func(cont_or_call: Optional[TypeContainerOrCallable]

--- a/andi/andi.py
+++ b/andi/andi.py
@@ -5,7 +5,6 @@ from typing import (
     get_type_hints, Tuple, cast)
 
 from andi.typeutils import get_union_args, is_union, get_globalns
-from andi.utils import as_class_names
 from andi.errors import CyclicDependencyError, NonProvidableError
 from inspect import signature, Parameter
 
@@ -267,13 +266,13 @@ def _plan(class_or_func: Union[Type, Callable],
 
         if not is_injectable(cls):
             raise NonProvidableError(
-                "Type {} cannot be provided".format(as_class_names(cls)))
+                "Type {} cannot be provided".format(cls))
 
 
         if cls in dependency_stack:
             raise CyclicDependencyError(
                 "Cyclic dependency found. Dependency graph: {}".format(
-                    " -> ".join(as_class_names(dependency_stack + [cls]))))
+                    " -> ".join(map(str, dependency_stack + [cls]))))
         dependency_stack = dependency_stack + [cls]
         arguments = inspect(cls.__init__)
     else:
@@ -291,12 +290,12 @@ def _plan(class_or_func: Union[Type, Callable],
                 if not types:
                     msg = "Parameter '{}' is lacking annotations in " \
                           "'{}.__init__()'. Not possible to build a plan".format(
-                        argname, as_class_names(class_or_func))
+                        argname, class_or_func)
                 else:
-                    msg = "Any of {} types are required ".format(as_class_names(types))
+                    msg = "Any of {} types are required ".format(types)
                     msg += " for parameter '{}' ".format(argname)
                     msg += " in '{}.__init__()' but none can be provided".format(
-                        as_class_names(class_or_func))
+                        class_or_func)
                 raise NonProvidableError(msg)
 
 

--- a/andi/typeutils.py
+++ b/andi/typeutils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import sys
-from typing import Union, List, Callable, Dict
+import inspect
+from typing import Union, List, Callable, Dict, Container
 
 
 def is_union(tp) -> bool:
@@ -38,6 +39,29 @@ def issubclass_safe(cls, bases) -> bool:
         return issubclass(cls, bases)
     except TypeError:
         return False
+
+
+def get_unannotated_params(func, annotations: Container) -> List[str]:
+    """ Return a list of ``func`` argument names which are not type annotated.
+
+    ``annotations`` should be a result of get_type_hints call for ``func``.
+
+    >>> from typing import get_type_hints
+    >>> def foo(x, y: str, *, z, w: int, **kwargs): pass
+    >>> annotations = get_type_hints(foo)
+    >>> get_unannotated_params(foo, annotations)
+    ['x', 'z']
+    """
+    ARGS_KWARGS = {
+        inspect.Parameter.VAR_POSITIONAL,  # **args argument
+        inspect.Parameter.VAR_KEYWORD      # **kwargs argument
+    }
+    res = []
+    for name, param in inspect.signature(func).parameters.items():
+        if name in annotations or param.kind in ARGS_KWARGS:
+            continue
+        res.append(name)
+    return res
 
 
 def get_globalns(func: Callable) -> Dict:

--- a/andi/typeutils.py
+++ b/andi/typeutils.py
@@ -53,7 +53,7 @@ def get_unannotated_params(func, annotations: Container) -> List[str]:
     ['x', 'z']
     """
     ARGS_KWARGS = {
-        inspect.Parameter.VAR_POSITIONAL,  # **args argument
+        inspect.Parameter.VAR_POSITIONAL,  # *args argument
         inspect.Parameter.VAR_KEYWORD      # **kwargs argument
     }
     res = []

--- a/andi/utils.py
+++ b/andi/utils.py
@@ -1,9 +1,0 @@
-def as_class_names(cls_or_collection):
-    try:
-        return [cls.__name__ for cls in cls_or_collection]
-    except:
-        try:
-            return cls_or_collection.__name__
-        except:
-            return str(cls_or_collection)
-

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,6 @@
 from typing import Optional, Dict, Type, Any
 
 from andi import Plan
-from andi.andi import FunctionArguments
 
 
 def build(plan: Plan, instances_stock: Optional[Dict[Type, Any]] = None):
@@ -11,8 +10,6 @@ def build(plan: Plan, instances_stock: Optional[Dict[Type, Any]] = None):
     for cls, params in plan.items():
         if cls in instances_stock:
             instances[cls] = instances_stock[cls]
-        elif cls == FunctionArguments:
-            pass
         else:
             kwargs = {param: instances[pcls]
                       for param, pcls in params.items()}


### PR DESCRIPTION
This PR contains more aggressive changes to #8.

Approach I intended to try (no progress so far):

* remove to_provide
* make a single andi.plan function
* the returned plan always return the passed object (function of class) as a last key/value in the plan. `_FunctionArguments` is removed.
* for all plan items except for the last one it is guaranteed that all arguments are provided
* for the last one it is guaranteed that all arguments are provided if strict=True is passed
* there is no distinction between classes and functions, they all work the same; the only difference is that internally for classes their `__init__` method is inspected.

For the caller, usage is the following, regardless of class/function:

```py
def _get_kwargs(instances, kwarg_classes):
    return {name: instances[cls] for name, cls in kwarg_classes.items()}

def build_deps(plan):  # Build all the instances from a plan
    instances = {}
    for cls, args in plan.dependencies:  # fixme: Plan class to make this code easier
        instances[cls] = cls(**_get_kwargs(instances, args))
    return instances

plan = andi.plan(fn, is_injectable={A, B})
instances = build_deps(plan)
fn(non_annotated='non_annotated',
    **_get_kwargs(instances, plan.final_params))  # fixme: Plan class

```