### PR TITLE
Support callable objects

### DIFF
--- a/andi/andi.py
+++ b/andi/andi.py
@@ -9,17 +9,26 @@ from andi.typeutils import (
     is_union,
     get_globalns,
     get_unannotated_params,
+    get_callable_func_obj,
 )
 from andi.errors import NonProvidableError, CyclicDependencyErrCase, \
     LackingAnnotationErrCase, NonInjectableOrExternalErrCase
 
 
-def inspect(func: Callable) -> Dict[str, List[Optional[Type]]]:
+def inspect(class_or_func: Callable) -> Dict[str, List[Optional[Type]]]:
     """
-    For each argument of the ``func`` return a list of possible types.
+    For each argument of the ``class_or_func`` return a list of possible types.
     Non annotated arguments are also returned with an empty list of possible
     types.
+
+    ``class_or_func`` can be
+
+    * a function
+    * a class - in this case ``cls.__init__`` annotations are returned
+    * a callable object - in this case ``obj.__call__`` annotations
+      are returned
     """
+    func = get_callable_func_obj(class_or_func)
     globalns = get_globalns(func)
     annotations = get_type_hints(func, globalns)
     for name in get_unannotated_params(func, annotations):
@@ -285,13 +294,7 @@ def _plan(class_or_func: Callable, *,
         return Plan(), [CyclicDependencyErrCase(class_or_func, dependency_stack)]
 
     dependency_stack = dependency_stack + [class_or_func]
-
-    is_class = isinstance(class_or_func, type)
-    if is_class:
-        cls = cast(Type, class_or_func)
-        arguments = inspect(cls.__init__)
-    else:
-        arguments = inspect(class_or_func)
+    arguments = inspect(class_or_func)
 
     args_errs = defaultdict(list)  # type: Dict[str, List[Tuple]]
     non_injectable_errs = defaultdict(list)  # type: Dict[str, List[Tuple]]

--- a/andi/andi.py
+++ b/andi/andi.py
@@ -2,7 +2,7 @@
 from collections import OrderedDict, defaultdict
 from typing import (
     Dict, List, Optional, Type, Callable, Union, Container,
-    get_type_hints, Tuple, cast, MutableMapping, Any, Mapping)
+    get_type_hints, Tuple, MutableMapping, Any, Mapping)
 
 from andi.typeutils import (
     get_union_args,
@@ -11,8 +11,12 @@ from andi.typeutils import (
     get_unannotated_params,
     get_callable_func_obj,
 )
-from andi.errors import NonProvidableError, CyclicDependencyErrCase, \
-    LackingAnnotationErrCase, NonInjectableOrExternalErrCase
+from andi.errors import (
+    NonProvidableError,
+    CyclicDependencyErrCase,
+    LackingAnnotationErrCase,
+    NonInjectableOrExternalErrCase
+)
 
 
 def inspect(class_or_func: Callable) -> Dict[str, List[Optional[Type]]]:

--- a/andi/typeutils.py
+++ b/andi/typeutils.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import sys
 import inspect
-from typing import Union, List, Callable, Dict, Container
+import types
+from typing import Union, List, Callable, Dict, Container, cast, Type
 
 
 def is_union(tp) -> bool:
@@ -101,3 +102,47 @@ def _get_globalns_for_attrs(func: Callable) -> Dict:
         # (w.r.t. typing.get_type_hints) but will still function
         # correctly.
         return {}
+
+
+def _get_function_types():
+    # from typing module (near get_type_hints), but without ModuleType
+    _function_types = [
+        types.FunctionType,
+        types.BuiltinFunctionType,
+        types.MethodType,
+    ]
+
+    # Python < 3.7 compatibility
+    for name in ['WrapperDescriptorType', 'MethodWrapperType', 'MethodDescriptorType']:
+        if hasattr(types, name):
+            _function_types.append(getattr(types, name))
+
+    return tuple(_function_types)
+
+
+_FUNCTION_TYPES = _get_function_types()
+
+
+def get_callable_func_obj(class_or_func: Callable) -> Callable:
+    """
+    Return a function/method which will be invoked
+    when func(...) is called. The resulting object should be
+    supported by ``get_type_hints``.
+    """
+    if not callable(class_or_func):
+        raise TypeError("%r is not callable" % (class_or_func,))
+    is_class = isinstance(class_or_func, type)
+    if is_class:
+        cls = cast(Type, class_or_func)
+        return cls.__init__
+    else:
+        # we need to check some exact types, because some function-like
+        # object also have __call__ method, while it is better
+        # not to use it, as get_type_hints support these objects as-is
+        if isinstance(class_or_func, _FUNCTION_TYPES):
+            return class_or_func
+        if hasattr(class_or_func, "__call__"):
+            return class_or_func.__call__  # type: ignore
+        else:
+            # not sure how to trigger it
+            raise TypeError("Unexpected callable object %r" % class_or_func)

--- a/andi/typeutils.py
+++ b/andi/typeutils.py
@@ -2,6 +2,7 @@
 import sys
 import inspect
 import types
+import functools
 from typing import Union, List, Callable, Dict, Container, cast, Type
 
 
@@ -141,8 +142,13 @@ def get_callable_func_obj(class_or_func: Callable) -> Callable:
         # not to use it, as get_type_hints support these objects as-is
         if isinstance(class_or_func, _FUNCTION_TYPES):
             return class_or_func
+        if isinstance(class_or_func, functools.partial):
+            raise NotImplementedError(
+                "functools.partial support is not implemented; "
+                "%r is passed" % (class_or_func,)
+            )
         if hasattr(class_or_func, "__call__"):
             return class_or_func.__call__  # type: ignore
         else:
             # not sure how to trigger it
-            raise TypeError("Unexpected callable object %r" % class_or_func)
+            raise TypeError("Unexpected callable object %r" % (class_or_func,))

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from functools import wraps
+from functools import wraps, partial
 from typing import Union, Optional, TypeVar, Type
 
 import pytest
@@ -116,6 +116,15 @@ def test_decorated():
         pass
 
     assert andi.inspect(func) == {'x': [Bar]}
+
+
+@pytest.mark.xfail(reason="functools.partial support is not implemented")
+def test_partial():
+    def func(x: Foo, y: Bar):
+        pass
+
+    func_nofoo = partial(func, x=Foo())
+    assert andi.inspect(func_nofoo) == {'y': [Bar]}
 
 
 def test_callable_object():

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -20,8 +20,6 @@ class Baz:
 
 
 def test_andi():
-    possible = {Foo, Bar, Baz}
-
     def func1(x: Foo):
         pass
 

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -90,6 +90,7 @@ def test_init_methods():
             self.x = x
 
     assert andi.inspect(MyClass.__init__) == {'x': [Foo]}
+    assert andi.inspect(MyClass) == {'x': [Foo]}
 
 
 def test_classmethod():
@@ -115,3 +116,12 @@ def test_decorated():
         pass
 
     assert andi.inspect(func) == {'x': [Bar]}
+
+
+def test_callable_object():
+    class MyClass:
+        def __call__(self, x: Bar):
+            pass
+
+    obj = MyClass()
+    assert andi.inspect(obj) == {'x': [Bar]}

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -262,7 +262,6 @@ def test_plan_with_optionals_and_union():
     ]
 
 
-
 def test_externally_provided():
     plan = andi.plan(E.__init__, is_injectable=ALL,
                      externally_provided=ALL)
@@ -326,7 +325,6 @@ def test_plan_for_func():
                   full_final_kwargs=True)
     assert error_causes(ex_info) == [
         ('other', [NonInjectableOrExternalErrCase('other', fn, [str])])]
-
 
 
 def test_plan_non_annotated_args():

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -400,3 +400,13 @@ def test_plan_use_fn_as_annotations(full_final_kwargs):
     assert plan.full_final_kwargs
     instances = build(plan)
     assert instances[fn].modified
+
+
+def test_plan_callable_object():
+    class MyFunc:
+        def __call__(self, b: B):
+            pass
+
+    func = MyFunc()
+    plan = andi.plan(func, is_injectable={B})
+    assert plan == [(B, {}), (func, {'b': B})]

--- a/tests/test_typeutils.py
+++ b/tests/test_typeutils.py
@@ -52,7 +52,6 @@ def test_get_callable_func_obj_class():
         get_callable_func_obj(foo)
 
 
-@pytest.mark.xfail(reason="TODO: figure out what's the correct behavior")
 def test_get_callable_func_classmethods():
     class Foo:
         @classmethod
@@ -61,8 +60,8 @@ def test_get_callable_func_classmethods():
 
     foo = Foo()
 
-    assert get_callable_func_obj(Foo.clsmeth) is Foo.clsmeth
-    assert get_callable_func_obj(foo.clsmeth) is foo.clsmeth
+    assert get_callable_func_obj(Foo.clsmeth) == Foo.clsmeth
+    assert get_callable_func_obj(foo.clsmeth) == foo.clsmeth
 
 
 def test_get_callable_func_obj_call():

--- a/tests/test_typeutils.py
+++ b/tests/test_typeutils.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from typing import Union, Optional
 
-from andi.typeutils import get_union_args
+import pytest
+
+from andi.typeutils import get_union_args, get_callable_func_obj
 
 
 def test_get_union_args():
@@ -10,3 +12,72 @@ def test_get_union_args():
 
 def test_get_union_args_optional():
     assert get_union_args(Optional[Union[str, int]]) == [str, int, None.__class__]
+
+
+def test_get_callable_func_obj_functions():
+    def foo():
+        pass
+
+    assert get_callable_func_obj(foo) is foo
+
+
+def test_get_callable_func_obj_class():
+
+    class Foo:
+        x = 5
+
+        def __init__(self):
+            pass
+
+        def meth(self):
+            pass
+
+        @staticmethod
+        def staticmeth(cls):
+            pass
+
+    foo = Foo()
+
+    # happy path
+    assert get_callable_func_obj(Foo) is Foo.__init__
+    assert get_callable_func_obj(Foo.meth) is Foo.meth
+    assert get_callable_func_obj(Foo.staticmeth) is Foo.staticmeth
+    assert get_callable_func_obj(foo.meth) == foo.meth
+    assert get_callable_func_obj(foo.staticmeth) is foo.staticmeth
+
+    with pytest.raises(TypeError):
+        get_callable_func_obj(Foo.x)  # type: ignore
+
+    with pytest.raises(TypeError):
+        get_callable_func_obj(foo)
+
+
+@pytest.mark.xfail(reason="TODO: figure out what's the correct behavior")
+def test_get_callable_func_classmethods():
+    class Foo:
+        @classmethod
+        def clsmeth(cls):
+            pass
+
+    foo = Foo()
+
+    assert get_callable_func_obj(Foo.clsmeth) is Foo.clsmeth
+    assert get_callable_func_obj(foo.clsmeth) is foo.clsmeth
+
+
+def test_get_callable_func_obj_call():
+    class Foo:
+        def __init__(self):
+            pass
+
+        def __call__(self):
+            pass
+
+        def meth(self):
+            pass
+
+    foo = Foo()
+
+    assert get_callable_func_obj(Foo) is Foo.__init__
+    assert get_callable_func_obj(foo.meth) == foo.meth
+    assert get_callable_func_obj(foo) == foo.__call__


### PR DESCRIPTION
Basically, this PR moves 

```py
    is_class = isinstance(class_or_func, type)
    if is_class:
        cls = cast(Type, class_or_func)
        arguments = inspect(cls.__init__)
    else:
        arguments = inspect(class_or_func)
```

code snippet to andi.inspect, and adds support for `__call__`-based callable objects.