### PR TITLE
Fix Travis deploy condition and bump tox env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,5 @@ deploy:
   on:
     tags: true
     repo: scrapinghub/andi
-    condition: $TOXENV == py37
+    condition: "$TOXENV = py38"
   distributions: "sdist bdist_wheel"


### PR DESCRIPTION
The comparison should be done with a single equal sign. I also took the change to change env from py37 to py38.