### PR TITLE
overrides

### DIFF
--- a/andi/andi.py
+++ b/andi/andi.py
@@ -384,10 +384,10 @@ def _select_type(types,
                  externally_provided,
                  overrides: Callable,
                  recursive_overrides: bool
-                 ) -> Tuple[Optional[Callable], Callable]:
+                 ) -> Tuple[Optional[Callable], OverrideFn]:
     """
     Choose the first type that can be provided. None otherwise. Also return
-    a boolean to keep track of overriding status.
+    the overrides function to be used from now on.
     """
     for candidate in types:
         candidate, new_overrides = _may_override(

--- a/andi/andi.py
+++ b/andi/andi.py
@@ -406,7 +406,7 @@ def _may_override(class_or_func, overrides: OverrideFn, recursive_overrides: boo
     """
     May override ``class_or_func`` if ``overrides`` function suggest it.
     In such a case, ``overrides`` function is replaced with ``_empty_overrides``
-    to stop overriding in children.
+    to stop overriding in children if recursive_overrides is disabled.
     """
     override = overrides(class_or_func)
     under_override = bool(override and override != class_or_func)


### PR DESCRIPTION
Implements a mechanism to override classes/functions in the dependencies tree. This opens the door to inject classes with different implementations (e.g. replace `PriceExtractorUsingCustomRules` by `PriceExtractorUsingAI` whenever you find it as a dependency)

Two modes are implemented. In the **recursive one**, overrides are applied whenever a candidate for overriding is found, even for the children of already overridden class/function. This behaviour might be useful in some situations: when overrides can be applied to subcomponents of already overridden components. Lets put an example. You might have to override `DBConnection`  with `MySQLDBConnection` and at the same time you might have to override `ListOfTasksPage` with `EvenCoolerListOfTasksPage` that depends on the `DBConnection`. The recursive mode allows performing both overrides at the same time so that `EvenCoolerListOfTasksPage` uses `MySQLDBConnection`. 

The drawback is that a cycle dependency error will be raised if your original class contain a default implementation and you want to override it but using the default implementation to enrich the result on top of it. For example, if you have a `PriceInEuroExtractor` and you want to override it with a `PriceInDollarExtractor`, but `PriceInDollarExtractor` depends on `PriceInEuroExtractor` to get the original price, because it will just apply some exchange rate over it. The **non recursive** method is there to make such a case working. That is, in this mode overrides are never applied to the children of a dependency.